### PR TITLE
d3d11 support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(${QUICKVLC_CORE}
     PRIVATE
         Qt6::Core
         Qt6::OpenGL
+        Qt6::Quick
         ${LIBVLC_LIBRARY}
         ${LIBVLCCORE_LIBRARY}
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,7 +29,6 @@ set(QUICKVLC_CORE_HEADERS
     media.h
     abstractvideostream.h
     vlc.h
-    openglvideostream.h
     abstractvideoframe.h
     videoframe.h
 )
@@ -43,7 +42,6 @@ set(QUICKVLC_CORE_SOURCES
     media.cpp
     abstractvideostream.cpp
     vlc.cpp
-    openglvideostream.cpp
     abstractvideoframe.cpp
     videoframe.cpp
 )
@@ -52,8 +50,22 @@ IF(MSVC OR MINGW)
     list(APPEND QUICKVLC_CORE_SOURCES
         compat/asprintf.c
         compat/vasprintf.c
+        d3d11videostream.h
+    )
+    list(APPEND QUICKVLC_CORE_SOURCES
+        d3d11videostream.cpp
+    )
+    list(APPEND QUICKVLC_CORE_HEADERS
+        d3d11videostream.h
     )
 ENDIF()
+list(APPEND QUICKVLC_CORE_HEADERS
+    openglvideostream.h
+)
+list(APPEND QUICKVLC_CORE_SOURCES
+    openglvideostream.cpp
+)
+
 
 add_library(${QUICKVLC_CORE} SHARED ${QUICKVLC_CORE_SOURCES} ${QUICKVLC_CORE_HEADERS} )
 

--- a/src/core/abstractvideoframe.h
+++ b/src/core/abstractvideoframe.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QSize>
+#include <QtQuick/QSGTexture>
 
 #include "core_shared_export.h"
 
@@ -45,6 +46,9 @@ public:
 
     void clear();
 
+    virtual bool isFlipped() const = 0;
+
+    virtual QSGTexture *getQSGTexture() = 0;
 private:
     QSize m_size;
 };

--- a/src/core/abstractvideostream.cpp
+++ b/src/core/abstractvideostream.cpp
@@ -46,7 +46,7 @@ AbstractVideoStream::~AbstractVideoStream()
 void AbstractVideoStream::setCallbacks(Vlc::MediaPlayer *player)
 {
     libvlc_video_set_output_callbacks(player->core(), videoEngine(), setup_cb, cleanup_cb, nullptr, update_output_cb, swap_cb,
-        make_current_cb, get_proc_address_cb, nullptr, nullptr, this);
+        make_current_cb, get_proc_address_cb, nullptr, select_plane_cb, this);
 }
 
 void AbstractVideoStream::unsetCallbacks(Vlc::MediaPlayer *player)
@@ -82,6 +82,11 @@ void AbstractVideoStream::swap_cb(void *opaque)
 bool AbstractVideoStream::make_current_cb(void *opaque, bool current)
 {
     return P_THIS->makeCurrent(current);
+}
+
+bool AbstractVideoStream::select_plane_cb(void *opaque, size_t plane, void *output)
+{
+    return P_THIS->selectPlane(plane, output);
 }
 
 void *AbstractVideoStream::get_proc_address_cb(void *opaque, const char *current)

--- a/src/core/abstractvideostream.cpp
+++ b/src/core/abstractvideostream.cpp
@@ -45,7 +45,7 @@ AbstractVideoStream::~AbstractVideoStream()
 
 void AbstractVideoStream::setCallbacks(Vlc::MediaPlayer *player)
 {
-    libvlc_video_set_output_callbacks(player->core(), videoEngine(), setup_cb, cleanup_cb, nullptr, resize_cb, swap_cb,
+    libvlc_video_set_output_callbacks(player->core(), videoEngine(), setup_cb, cleanup_cb, nullptr, update_output_cb, swap_cb,
         make_current_cb, get_proc_address_cb, nullptr, nullptr, this);
 }
 
@@ -57,10 +57,10 @@ void AbstractVideoStream::unsetCallbacks(Vlc::MediaPlayer *player)
     }
 }
 
-bool AbstractVideoStream::resize_cb(
+bool AbstractVideoStream::update_output_cb(
     void *opaque, const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg)
 {
-    return P_THIS->resize(cfg, render_cfg);
+    return P_THIS->updateOutput(cfg, render_cfg);
 }
 
 bool AbstractVideoStream::setup_cb(

--- a/src/core/abstractvideostream.cpp
+++ b/src/core/abstractvideostream.cpp
@@ -35,7 +35,7 @@ static inline AbstractVideoStream *p_this(void **opaque)
 
 #define P_THIS p_this(opaque)
 
-AbstractVideoStream::AbstractVideoStream()
+AbstractVideoStream::AbstractVideoStream(QObject *parent) : QObject(parent)
 {
 }
 

--- a/src/core/abstractvideostream.h
+++ b/src/core/abstractvideostream.h
@@ -53,7 +53,7 @@ public slots:
 
 protected:
     virtual libvlc_video_engine_t videoEngine() = 0;
-    virtual bool resize(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) = 0;
+    virtual bool updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) = 0;
     virtual bool setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out) = 0;
     virtual void cleanup() = 0;
     virtual void swap() = 0;
@@ -61,10 +61,11 @@ protected:
     virtual void *getProcAddress(const char *current) = 0;
 
 private:
-    static bool resize_cb(void *opaque, const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg);
     static bool setup_cb(
         void **opaque, const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out);
     static void cleanup_cb(void *opaque);
+    static bool update_output_cb(
+        void *opaque, const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg);
     static void swap_cb(void *opaque);
     static bool make_current_cb(void *opaque, bool current);
     static void *get_proc_address_cb(void *opaque, const char *current);

--- a/src/core/abstractvideostream.h
+++ b/src/core/abstractvideostream.h
@@ -30,7 +30,7 @@
 namespace Vlc {
 
 class MediaPlayer;
-class VideoFrame;
+class AbstractVideoFrame;
 
 class QUICKVLC_CORE_EXPORT AbstractVideoStream : public QObject
 {
@@ -43,7 +43,7 @@ public:
 
     void unsetCallbacks(Vlc::MediaPlayer *player);
 
-    virtual std::shared_ptr<VideoFrame> getVideoFrame() = 0;
+    virtual std::shared_ptr<AbstractVideoFrame> getVideoFrame() = 0;
 
 signals:
     void frameUpdated();

--- a/src/core/abstractvideostream.h
+++ b/src/core/abstractvideostream.h
@@ -19,23 +19,37 @@
 
 #pragma once
 
+#include <memory>
+
 #include <vlc/vlc.h>
 
+#include <QObject>
 #include "core_shared_export.h"
+
 
 namespace Vlc {
 
 class MediaPlayer;
+class VideoFrame;
 
-class QUICKVLC_CORE_EXPORT AbstractVideoStream
+class QUICKVLC_CORE_EXPORT AbstractVideoStream : public QObject
 {
+    Q_OBJECT
 public:
-    explicit AbstractVideoStream();
+    explicit AbstractVideoStream(QObject *parent = nullptr);
     virtual ~AbstractVideoStream();
 
     void setCallbacks(Vlc::MediaPlayer *player);
 
     void unsetCallbacks(Vlc::MediaPlayer *player);
+
+    virtual std::shared_ptr<VideoFrame> getVideoFrame() = 0;
+
+signals:
+    void frameUpdated();
+
+public slots:
+    virtual void initContext() = 0;
 
 protected:
     virtual libvlc_video_engine_t videoEngine() = 0;

--- a/src/core/abstractvideostream.h
+++ b/src/core/abstractvideostream.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include "core_shared_export.h"
 
+class QQuickWindow;
 
 namespace Vlc {
 
@@ -42,6 +43,8 @@ public:
     void setCallbacks(Vlc::MediaPlayer *player);
 
     void unsetCallbacks(Vlc::MediaPlayer *player);
+
+    virtual void windowChanged(QQuickWindow *window) = 0;
 
     virtual std::shared_ptr<AbstractVideoFrame> getVideoFrame() = 0;
 

--- a/src/core/abstractvideostream.h
+++ b/src/core/abstractvideostream.h
@@ -58,6 +58,7 @@ protected:
     virtual void cleanup() = 0;
     virtual void swap() = 0;
     virtual bool makeCurrent(bool isCurrent) = 0;
+    virtual bool selectPlane(size_t plane, void *output) = 0;
     virtual void *getProcAddress(const char *current) = 0;
 
 private:
@@ -68,6 +69,7 @@ private:
         void *opaque, const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg);
     static void swap_cb(void *opaque);
     static bool make_current_cb(void *opaque, bool current);
+    static bool select_plane_cb(void *opaque, size_t plane, void *output);
     static void *get_proc_address_cb(void *opaque, const char *current);
 };
 

--- a/src/core/common.cpp
+++ b/src/core/common.cpp
@@ -37,6 +37,9 @@ QStringList args()
                  << "--no-osd"
                  << "--no-loop"
                  << "--no-video-title-show"
+#if defined(Q_OS_WIN)
+                 << "--dec-dev=dxva2"
+#endif
 #if defined(Q_OS_DARWIN)
                  << "--vout=macosx"
 #endif

--- a/src/core/d3d11videostream.cpp
+++ b/src/core/d3d11videostream.cpp
@@ -1,0 +1,342 @@
+/******************************************************************************
+ * This file is part of QuickVLC - Qt and libvlc connection library.
+ * Copyright (C) 2022 Alexey Avramchik (OU Bamboo group) <aa@bam-boo.eu>
+ *
+ * QuickVLC is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * QuickVLC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuickVLC. If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#include "d3d11videostream.h"
+#include "abstractvideoframe.h"
+
+#include <QDebug>
+#include <QtQuick/qsgtexture_platform.h>
+#include <QtQuick/qsgrendererinterface.h>
+
+#include <d3d11_1.h>
+#include <dxgi1_2.h>
+#include <wrl.h>
+
+using namespace Microsoft::WRL;
+
+namespace Vlc {
+
+class D3DVideoFrame : public AbstractVideoFrame
+{
+public:
+    virtual ~D3DVideoFrame()
+    {
+        cleanup();
+    }
+
+    void cleanup()
+    {
+        m_renderTarget.Reset();
+        m_qtTexture.Reset();
+        if (m_sharedHandle) {
+            CloseHandle(m_sharedHandle);
+            m_sharedHandle = nullptr;
+        }
+        clear();
+    }
+
+    bool init(QQuickWindow *window, int width, int height, ComPtr<ID3D11Device> &qtD3DDevice,
+        ComPtr<ID3D11Device> &vlcD3DDevice)
+    {
+        setSize({ width, height });
+
+        m_window = window;
+
+        HRESULT hr;
+
+        D3D11_TEXTURE2D_DESC texDesc = {};
+        texDesc.MipLevels = 1;
+        texDesc.SampleDesc.Count = 1;
+
+        texDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+        texDesc.Usage = D3D11_USAGE_DEFAULT;
+        texDesc.CPUAccessFlags = 0;
+        texDesc.ArraySize = 1;
+        texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        texDesc.Height = height;
+        texDesc.Width = width;
+        texDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
+        hr = qtD3DDevice->CreateTexture2D(&texDesc, nullptr, &m_qtTexture);
+        if (FAILED(hr)) {
+            return false;
+            qWarning() << "fail to create D3D Qt texture";
+
+        }
+
+        // share texture between VLC and Qt
+        {
+            ComPtr<IDXGIResource1> sharedResource;
+            m_qtTexture.As(&sharedResource);
+            hr = sharedResource->CreateSharedHandle(
+                nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr, &m_sharedHandle);
+            if (FAILED(hr)) {
+                qWarning() << "fail to create texture shared handle";
+                return false;
+            }
+        }
+
+        ComPtr<ID3D11Texture2D> texture2D;
+        {
+            ComPtr<ID3D11Device1> device1;
+            vlcD3DDevice.As(&device1);
+            hr = device1->OpenSharedResource1(m_sharedHandle, IID_PPV_ARGS(&texture2D));
+            if (FAILED(hr)) {
+                qWarning() << "fail to open shared handle";
+                return false;
+            }
+                
+        }
+
+        D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc =
+            CD3D11_RENDER_TARGET_VIEW_DESC(
+                D3D11_RTV_DIMENSION_TEXTURE2D, 
+                texDesc.Format);
+        vlcD3DDevice->CreateRenderTargetView(texture2D.Get(), &renderTargetViewDesc, &m_renderTarget);
+        if (FAILED(hr) || !m_renderTarget) {
+            qWarning() << "fail to create render target view";
+            return false;
+        }
+
+        return true;
+    }
+
+    bool isFlipped() const override
+    {
+        return false;
+    }
+
+    QSGTexture *getQSGTexture() override
+    {
+        if (!m_qtTexture)
+            return nullptr;
+
+        return QNativeInterface::QSGD3D11Texture::fromNative(m_qtTexture.Get(), m_window, size());
+    }
+
+public:
+    QQuickWindow *m_window = nullptr;
+    ComPtr<ID3D11Texture2D> m_qtTexture;
+    HANDLE m_sharedHandle = nullptr;  // handle of the texture used by VLC and the app
+    ComPtr<ID3D11RenderTargetView> m_renderTarget;
+
+
+};
+
+static const FLOAT BLACK_RGBA[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+static const FLOAT RED_RGBA[4] = { 1.0f, 0.0f, 0.0f, 1.0f };
+
+struct D3D11VideoStream::D3D11VideoStreamPrivate 
+{
+    //Qt resources
+    ComPtr<ID3D11Device> qtD3DDevice;
+    QQuickWindow *window = nullptr;
+
+    //VLC resources
+    ComPtr<ID3D11Device> vlcD3DDevice;
+    ComPtr<ID3D11DeviceContext> vlcD3DContext;
+
+    std::shared_ptr<D3DVideoFrame> renderTexture;
+    std::shared_ptr<D3DVideoFrame> swapTexture;
+    std::shared_ptr<D3DVideoFrame> displayTexture;
+
+    unsigned width = 800;
+    unsigned height = 0;
+
+    QMutex text_lock;
+
+    bool updated = false;
+};
+
+D3D11VideoStream::D3D11VideoStream(QQuickItem *parent) 
+    : AbstractVideoStream(parent)
+{
+    m_priv = std::make_unique<D3D11VideoStreamPrivate>();
+}
+
+D3D11VideoStream::~D3D11VideoStream()
+{
+    cleanup();
+}
+
+void D3D11VideoStream::windowChanged(QQuickWindow *window)
+{
+    m_priv->window = window;
+
+}
+
+void D3D11VideoStream::initContext()
+{
+    Q_ASSERT(QSGRendererInterface::isApiRhiBased(QSGRendererInterface::Direct3D11));
+
+    if (m_priv->vlcD3DDevice)
+        return;
+
+    HRESULT hr;
+
+    QSGRendererInterface *qri = m_priv->window->rendererInterface();
+    assert(qri->isApiRhiBased(QSGRendererInterface::Direct3D11));
+    m_priv->qtD3DDevice =
+        static_cast<ID3D11Device *>(qri->getResource(m_priv->window, QSGRendererInterface::DeviceResource));
+
+    //Create vlc D3D device
+
+    UINT creationFlags = D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+    //| D3D11_CREATE_DEVICE_DEBUG;
+    
+    D3D_FEATURE_LEVEL requestedFeaturesLevels[] = {
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+    };
+
+    hr = D3D11CreateDevice(
+        nullptr, // Adapter
+        D3D_DRIVER_TYPE_HARDWARE,
+        nullptr, // Module
+        creationFlags,
+        requestedFeaturesLevels, 
+        sizeof(requestedFeaturesLevels) / sizeof(*requestedFeaturesLevels),
+        D3D11_SDK_VERSION,
+        &m_priv->vlcD3DDevice,
+        nullptr, //actual feature level
+        &m_priv->vlcD3DContext
+    );
+
+    if (FAILED(hr)) {
+        qWarning() << "can't create D3D device";
+    }
+
+    ComPtr<ID3D10Multithread> d3dMultithread;
+    hr = m_priv->vlcD3DContext.As(&d3dMultithread);
+    if (FAILED(hr)) {
+        qWarning() << "can't setup D3D multithread protection";
+    } else {
+        d3dMultithread->SetMultithreadProtected(TRUE);
+    }
+    
+
+    m_videoReady.release();
+}
+
+libvlc_video_engine_t D3D11VideoStream::videoEngine()
+{
+    return libvlc_video_engine_d3d11;
+}
+
+std::shared_ptr<AbstractVideoFrame> D3D11VideoStream::getVideoFrame()
+{
+    QMutexLocker locker(&m_priv->text_lock);
+    if (m_priv->updated) {
+        std::swap(m_priv->swapTexture, m_priv->displayTexture);
+        m_priv->updated = false;
+    }
+    return m_priv->displayTexture;
+}
+
+bool D3D11VideoStream::updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg)
+{
+    if (m_priv->width != cfg->width || m_priv->height != cfg->height)
+    {
+        m_priv->width = cfg->width;
+        m_priv->height = cfg->height;
+
+        QMutexLocker locker(&m_priv->text_lock);
+        m_priv->swapTexture = std::make_shared<D3DVideoFrame>();
+        m_priv->swapTexture->init(
+            m_priv->window, m_priv->width, m_priv->height, m_priv->qtD3DDevice, m_priv->vlcD3DDevice);
+        m_priv->renderTexture = std::make_shared<D3DVideoFrame>();
+        m_priv->renderTexture->init(
+            m_priv->window, m_priv->width, m_priv->height, m_priv->qtD3DDevice, m_priv->vlcD3DDevice);
+        m_priv->displayTexture = std::make_shared<D3DVideoFrame>();
+        m_priv->displayTexture->init(
+            m_priv->window, m_priv->width, m_priv->height, m_priv->qtD3DDevice, m_priv->vlcD3DDevice);
+    }
+
+    render_cfg->dxgi_format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    render_cfg->full_range = true;
+    render_cfg->colorspace = libvlc_video_colorspace_BT709;
+    render_cfg->primaries = libvlc_video_primaries_BT709;
+    render_cfg->transfer = libvlc_video_transfer_func_SRGB;
+    render_cfg->orientation = libvlc_video_orient_top_left;
+
+    return true;
+}
+
+bool D3D11VideoStream::setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out)
+{
+    Q_UNUSED(cfg)
+
+    /* Wait for rendering view to be ready. */
+    m_videoReady.acquire();
+
+    out->d3d11.device_context = m_priv->vlcD3DContext.Get();
+
+    m_priv->width = 0;
+    m_priv->height = 0;
+
+    return true;
+}
+
+void D3D11VideoStream::cleanup()
+{
+    m_videoReady.release();
+
+    QMutexLocker locker(&m_priv->text_lock);
+    m_priv->renderTexture.reset();
+    m_priv->swap1Texture.reset();
+    m_priv->swap2Texture.reset();
+    m_priv->displayTexture.reset();
+}
+
+void D3D11VideoStream::swap()
+{
+    {
+        QMutexLocker locker(&m_priv->text_lock);
+        m_priv->updated = true;
+        std::swap(m_priv->renderTexture, m_priv->swap1Texture);
+    }
+    emit frameUpdated();
+}
+
+bool D3D11VideoStream::makeCurrent(bool isCurrent)
+{
+    if (isCurrent) {
+        m_priv->vlcD3DContext->ClearRenderTargetView(
+            m_priv->renderTexture->m_renderTarget.Get(), BLACK_RGBA);
+    }
+    return true;
+}
+
+bool D3D11VideoStream::selectPlane(size_t plane, void *outputPtr)
+{
+    if (plane != 0)
+        return false;
+
+    ID3D11RenderTargetView **output = static_cast<ID3D11RenderTargetView **>(outputPtr);
+    *output = m_priv->renderTexture->m_renderTarget.Get();
+
+    return true;
+}
+
+void *D3D11VideoStream::getProcAddress(const char *current)
+{
+    //N/A OpenGL only
+    return nullptr;
+}
+
+}  // namespace Vlc

--- a/src/core/d3d11videostream.cpp
+++ b/src/core/d3d11videostream.cpp
@@ -152,7 +152,8 @@ struct D3D11VideoStream::D3D11VideoStreamPrivate
     ComPtr<ID3D11DeviceContext> vlcD3DContext;
 
     std::shared_ptr<D3DVideoFrame> renderTexture;
-    std::shared_ptr<D3DVideoFrame> swapTexture;
+    std::shared_ptr<D3DVideoFrame> swap1Texture;
+    std::shared_ptr<D3DVideoFrame> swap2Texture;
     std::shared_ptr<D3DVideoFrame> displayTexture;
 
     unsigned width = 800;
@@ -242,7 +243,8 @@ std::shared_ptr<AbstractVideoFrame> D3D11VideoStream::getVideoFrame()
 {
     QMutexLocker locker(&m_priv->text_lock);
     if (m_priv->updated) {
-        std::swap(m_priv->swapTexture, m_priv->displayTexture);
+        std::swap(m_priv->swap1Texture, m_priv->swap2Texture);
+        std::swap(m_priv->swap2Texture, m_priv->displayTexture);
         m_priv->updated = false;
     }
     return m_priv->displayTexture;
@@ -256,8 +258,11 @@ bool D3D11VideoStream::updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc
         m_priv->height = cfg->height;
 
         QMutexLocker locker(&m_priv->text_lock);
-        m_priv->swapTexture = std::make_shared<D3DVideoFrame>();
-        m_priv->swapTexture->init(
+        m_priv->swap1Texture = std::make_shared<D3DVideoFrame>();
+        m_priv->swap1Texture->init(
+            m_priv->window, m_priv->width, m_priv->height, m_priv->qtD3DDevice, m_priv->vlcD3DDevice);
+        m_priv->swap2Texture = std::make_shared<D3DVideoFrame>();
+        m_priv->swap2Texture->init(
             m_priv->window, m_priv->width, m_priv->height, m_priv->qtD3DDevice, m_priv->vlcD3DDevice);
         m_priv->renderTexture = std::make_shared<D3DVideoFrame>();
         m_priv->renderTexture->init(

--- a/src/core/d3d11videostream.h
+++ b/src/core/d3d11videostream.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * This file is part of QuickVLC - Qt and libvlc connection library.
+ * Copyright (C) 2022 Alexey Avramchik (OU Bamboo group) <aa@bam-boo.eu>
+ *
+ * QuickVLC is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * QuickVLC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuickVLC. If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#pragma once
+
+#include <QMutex>
+#include <QSemaphore>
+#include <QtQuick/QQuickItem>
+
+#include "abstractvideostream.h"
+#include "core_shared_export.h"
+
+namespace Vlc {
+
+class AbstractVideoFrame;
+
+class QUICKVLC_CORE_EXPORT D3D11VideoStream : public AbstractVideoStream
+{
+
+public:
+    explicit D3D11VideoStream(QQuickItem *parent = nullptr);
+    ~D3D11VideoStream();
+
+    void windowChanged(QQuickWindow *window) override;
+    std::shared_ptr<AbstractVideoFrame> getVideoFrame() override;
+    
+    void initContext() override;
+
+private:
+    libvlc_video_engine_t videoEngine() override;
+    bool updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) override;
+    bool setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out) override;
+    void cleanup() override;
+    void swap() override;
+    bool makeCurrent(bool isCurrent) override;
+    bool selectPlane(size_t plane, void *output) override;
+    void *getProcAddress(const char *current) override;
+
+    QSemaphore m_videoReady;
+
+    struct D3D11VideoStreamPrivate;
+    std::unique_ptr<D3D11VideoStreamPrivate> m_priv;
+};
+
+}  // namespace Vlc

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<VideoFrame> OpenGLVideoStream::getVideoFrame()
     return m_videoFrame;
 }
 
-bool OpenGLVideoStream::resize(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg)
+bool OpenGLVideoStream::updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg)
 {
     {
         QMutexLocker locker(&m_text_lock);

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -19,10 +19,11 @@
 #include "openglvideostream.h"
 
 #include <QOpenGLContext>
+#include <QQuickItem>
 
 namespace Vlc {
 
-OpenGLVideoStream::OpenGLVideoStream(QObject *parent)
+OpenGLVideoStream::OpenGLVideoStream(QQuickItem *parent)
     : AbstractVideoStream { parent }
 {
     m_context = new QOpenGLContext(parent);

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -22,7 +22,8 @@
 
 namespace Vlc {
 
-OpenGLVideoStream::OpenGLVideoStream(QObject *parent) : QObject { parent }
+OpenGLVideoStream::OpenGLVideoStream(QObject *parent)
+    : AbstractVideoStream { parent }
 {
     m_context = new QOpenGLContext(parent);
     m_surface = new QOffscreenSurface(nullptr, parent);

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -153,6 +153,12 @@ void OpenGLVideoStream::swap()
     m_buffers[m_idx_render]->bind();
 }
 
+bool OpenGLVideoStream::selectPlane(size_t plane, void *output)
+{
+    //N/A
+    return true;
+}
+
 bool OpenGLVideoStream::makeCurrent(bool isCurrent)
 {
     if (isCurrent) {

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -35,6 +35,11 @@ OpenGLVideoStream::~OpenGLVideoStream()
     cleanup();
 }
 
+void OpenGLVideoStream::windowChanged(QQuickWindow *window)
+{
+    m_window = window;
+}
+
 void OpenGLVideoStream::initContext()
 {
     //    Q_ASSERT(QSGRendererInterface::isApiRhiBased(QSGRendererInterface::OpenGL));

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<AbstractVideoFrame> OpenGLVideoStream::getVideoFrame()
         std::swap(m_idx_swap, m_idx_display);
 
         if (m_buffers[m_idx_display]) {
-            m_videoFrame = std::make_shared<VideoFrame>(m_buffers[m_idx_display].get());
+            m_videoFrame = std::make_shared<OpenGLVideoFrame>(m_buffers[m_idx_display].get(), m_window);
         } else {
             m_videoFrame = {};
         }

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -61,7 +61,7 @@ libvlc_video_engine_t OpenGLVideoStream::videoEngine()
     return m_context->isOpenGLES() ? libvlc_video_engine_gles2 : libvlc_video_engine_opengl;
 }
 
-std::shared_ptr<VideoFrame> OpenGLVideoStream::getVideoFrame()
+std::shared_ptr<AbstractVideoFrame> OpenGLVideoStream::getVideoFrame()
 {
     QMutexLocker locker(&m_text_lock);
 

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -150,11 +150,9 @@ void OpenGLVideoStream::swap()
 
     m_updated = true;
 
-    QMetaObject::invokeMethod(this, &OpenGLVideoStream::frameUpdated, Qt::QueuedConnection);
-
-    //    frameUpdated();
-
     std::swap(m_idx_swap, m_idx_render);
+
+    emit frameUpdated();
 
     m_buffers[m_idx_render]->bind();
 }

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -43,7 +43,7 @@ public:
 
 private:
     libvlc_video_engine_t videoEngine() override;
-    bool resize(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) override;
+    bool updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) override;
     bool setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out) override;
     void cleanup() override;
     void swap() override;

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -34,7 +34,7 @@ namespace Vlc {
 class QUICKVLC_CORE_EXPORT OpenGLVideoStream : public AbstractVideoStream, protected QOpenGLFunctions
 {
 public:
-    explicit OpenGLVideoStream(QObject *parent = nullptr);
+    explicit OpenGLVideoStream(QQuickItem *parent = nullptr);
     ~OpenGLVideoStream();
 
     std::shared_ptr<AbstractVideoFrame> getVideoFrame() override;

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -39,6 +39,7 @@ public:
 
     std::shared_ptr<AbstractVideoFrame> getVideoFrame() override;
 
+    void windowChanged(QQuickWindow *window) override;
     void initContext() override;
 
 private:
@@ -51,9 +52,10 @@ private:
     bool makeCurrent(bool isCurrent) override;
     void *getProcAddress(const char *current) override;
 
-    QOpenGLContext *m_context;
-    QOffscreenSurface *m_surface;
+    QOpenGLContext *m_context = nullptr;
+    QOffscreenSurface *m_surface = nullptr;
     QSemaphore m_videoReady;
+    QQuickWindow *m_window = nullptr;
 
     unsigned m_width = 0;
     unsigned m_height = 0;

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -69,7 +69,7 @@ private:
 
     bool m_updated = false;
 
-    std::shared_ptr<VideoFrame> m_videoFrame;
+    std::shared_ptr<OpenGLVideoFrame> m_videoFrame;
 };
 
 }  // namespace Vlc

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -47,6 +47,7 @@ private:
     bool setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out) override;
     void cleanup() override;
     void swap() override;
+    bool selectPlane(size_t plane, void *output) override;
     bool makeCurrent(bool isCurrent) override;
     void *getProcAddress(const char *current) override;
 

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -31,22 +31,17 @@
 
 namespace Vlc {
 
-class QUICKVLC_CORE_EXPORT OpenGLVideoStream : public QObject, public AbstractVideoStream, protected QOpenGLFunctions
+class QUICKVLC_CORE_EXPORT OpenGLVideoStream : public AbstractVideoStream, protected QOpenGLFunctions
 {
-    Q_OBJECT
-
 public:
     explicit OpenGLVideoStream(QObject *parent = nullptr);
     ~OpenGLVideoStream();
 
-    std::shared_ptr<VideoFrame> getVideoFrame();
+    std::shared_ptr<VideoFrame> getVideoFrame() override;
 
-public slots:
-    void initContext();
+    void initContext() override;
 
 private:
-    Q_INVOKABLE virtual void frameUpdated() = 0;
-
     libvlc_video_engine_t videoEngine() override;
     bool resize(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg) override;
     bool setup(const libvlc_video_setup_device_cfg_t *cfg, libvlc_video_setup_device_info_t *out) override;

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -37,7 +37,7 @@ public:
     explicit OpenGLVideoStream(QObject *parent = nullptr);
     ~OpenGLVideoStream();
 
-    std::shared_ptr<VideoFrame> getVideoFrame() override;
+    std::shared_ptr<AbstractVideoFrame> getVideoFrame() override;
 
     void initContext() override;
 

--- a/src/core/videoframe.cpp
+++ b/src/core/videoframe.cpp
@@ -18,21 +18,24 @@
  ******************************************************************************/
 
 #include "videoframe.h"
+#include <QtQuick/qsgtexture_platform.h>
 
 namespace Vlc {
 
-VideoFrame::VideoFrame(QOpenGLFramebufferObject *fbo) : AbstractVideoFrame()
+OpenGLVideoFrame::OpenGLVideoFrame(QOpenGLFramebufferObject *fbo, QQuickWindow* window) 
+    : AbstractVideoFrame()
+    , m_window(window)
 {
     m_textureId = fbo->texture();
 
     setSize(fbo->size());
 }
 
-VideoFrame::~VideoFrame()
+OpenGLVideoFrame::~OpenGLVideoFrame()
 {
 }
 
-GLuint VideoFrame::texture() const
+GLuint OpenGLVideoFrame::texture() const
 {
     return m_textureId;
 }

--- a/src/core/videoframe.cpp
+++ b/src/core/videoframe.cpp
@@ -40,4 +40,15 @@ GLuint OpenGLVideoFrame::texture() const
     return m_textureId;
 }
 
+bool OpenGLVideoFrame::isFlipped() const
+{
+    //OpenGL textures are upside down
+    return true;
+}
+
+QSGTexture *OpenGLVideoFrame::getQSGTexture()
+{
+    return QNativeInterface::QSGOpenGLTexture::fromNative(m_textureId, m_window, size());
+}
+
 }  // namespace Vlc

--- a/src/core/videoframe.h
+++ b/src/core/videoframe.h
@@ -35,6 +35,10 @@ public:
 
     GLuint texture() const;
 
+    bool isFlipped() const override;
+
+    QSGTexture *getQSGTexture() override;
+
 private:
     GLuint m_textureId;
     QQuickWindow *m_window;

--- a/src/core/videoframe.h
+++ b/src/core/videoframe.h
@@ -26,17 +26,18 @@
 
 namespace Vlc {
 
-class QUICKVLC_CORE_EXPORT VideoFrame : public AbstractVideoFrame
+class QUICKVLC_CORE_EXPORT OpenGLVideoFrame : public AbstractVideoFrame
 {
 public:
-    explicit VideoFrame(QOpenGLFramebufferObject *fbo);
+    explicit OpenGLVideoFrame(QOpenGLFramebufferObject *fbo, QQuickWindow *window);
 
-    ~VideoFrame();
+    ~OpenGLVideoFrame();
 
     GLuint texture() const;
 
 private:
     GLuint m_textureId;
+    QQuickWindow *m_window;
 };
 
 }  // namespace Vlc

--- a/src/qml/mediasource.cpp
+++ b/src/qml/mediasource.cpp
@@ -56,6 +56,7 @@ void MediaSource::deregisterVideoOutput(VideoOutput *output)
 
 void MediaSource::handleWindowChanged(QQuickWindow *window)
 {
+    m_videoStream->windowChanged(window);
     if (window) {
         connect(window, &QQuickWindow::beforeSynchronizing, this, &MediaSource::sync, Qt::DirectConnection);
         connect(window, &QQuickWindow::sceneGraphInvalidated, this, &MediaSource::cleanup, Qt::DirectConnection);

--- a/src/qml/mediasource.cpp
+++ b/src/qml/mediasource.cpp
@@ -71,3 +71,8 @@ void MediaSource::sync()
 void MediaSource::cleanup()
 {
 }
+
+std::shared_ptr<Vlc::AbstractVideoFrame> MediaSource::getVideoFrame()
+{
+    return m_videoStream->getVideoFrame();
+}

--- a/src/qml/mediasource.h
+++ b/src/qml/mediasource.h
@@ -27,6 +27,7 @@
 
 namespace Vlc {
 class MediaPlayer;
+class AbstractVideoFrame;
 };
 
 class VideoOutput;
@@ -48,6 +49,8 @@ public:
     virtual void registerVideoOutput(VideoOutput *output);
 
     virtual void deregisterVideoOutput(VideoOutput *output);
+
+    std::shared_ptr<Vlc::AbstractVideoFrame> getVideoFrame();
 
 public slots:
     void sync();

--- a/src/qml/rendering/videomaterial.cpp
+++ b/src/qml/rendering/videomaterial.cpp
@@ -50,7 +50,7 @@ QSGTexture *VideoMaterial::getTexture()
 
 void VideoMaterial::updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
 {
-    m_videoFrame = std::static_pointer_cast<Vlc::VideoFrame>(frame);
+    m_videoFrame = std::static_pointer_cast<Vlc::OpenGLVideoFrame>(frame);
 
     m_texture->setNativeObject(m_videoFrame->texture(), m_videoFrame->size());
     m_texture->updateTexture();

--- a/src/qml/rendering/videomaterial.cpp
+++ b/src/qml/rendering/videomaterial.cpp
@@ -50,8 +50,5 @@ QSGTexture *VideoMaterial::getTexture()
 
 void VideoMaterial::updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
 {
-    m_videoFrame = std::static_pointer_cast<Vlc::OpenGLVideoFrame>(frame);
-
-    m_texture->setNativeObject(m_videoFrame->texture(), m_videoFrame->size());
-    m_texture->updateTexture();
+    m_texture.reset(frame->getQSGTexture());
 }

--- a/src/qml/rendering/videomaterial.h
+++ b/src/qml/rendering/videomaterial.h
@@ -38,5 +38,5 @@ public:
 
 private:
     std::unique_ptr<VideoTexture> m_texture;
-    std::shared_ptr<Vlc::VideoFrame> m_videoFrame;
+    std::shared_ptr<Vlc::OpenGLVideoFrame> m_videoFrame;
 };

--- a/src/qml/rendering/videomaterial.h
+++ b/src/qml/rendering/videomaterial.h
@@ -37,6 +37,5 @@ public:
     void updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame);
 
 private:
-    std::unique_ptr<VideoTexture> m_texture;
-    std::shared_ptr<Vlc::OpenGLVideoFrame> m_videoFrame;
+    std::unique_ptr<QSGTexture> m_texture;
 };

--- a/src/qml/rendering/videonode.cpp
+++ b/src/qml/rendering/videonode.cpp
@@ -26,6 +26,7 @@ VideoNode::VideoNode()
 
 void VideoNode::updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
 {
+    m_frame = frame;
     setTexture(frame->getQSGTexture());
 
     if (frame->isFlipped())

--- a/src/qml/rendering/videonode.cpp
+++ b/src/qml/rendering/videonode.cpp
@@ -18,20 +18,20 @@
 
 #include "videonode.h"
 
-VideoNode::VideoNode() : m_geometry { QSGGeometry::defaultAttributes_TexturedPoint2D(), 4 }
+VideoNode::VideoNode()
 {
-    setGeometry(&m_geometry);
-    setMaterial(&m_material);
-}
-
-void VideoNode::setRect(const QRectF &rect, const QRectF &sourceRect)
-{
-    QSGGeometry::updateTexturedRectGeometry(&m_geometry, rect, sourceRect);
-
-    markDirty(QSGNode::DirtyGeometry);
+    setFiltering(QSGTexture::Linear);
+    setOwnsTexture(true);
 }
 
 void VideoNode::updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
 {
-    m_material.updateFrame(frame);
+    setTexture(frame->getQSGTexture());
+
+    if (frame->isFlipped())
+        setTextureCoordinatesTransform(MirrorVertically);
+    else
+        setTextureCoordinatesTransform(NoTransform);
+
+    markDirty(QSGNode::DirtyMaterial);
 }

--- a/src/qml/rendering/videonode.h
+++ b/src/qml/rendering/videonode.h
@@ -20,19 +20,14 @@
 
 #include <core/videoframe.h>
 
-#include <QSGGeometryNode>
+#include <QSGSimpleTextureNode>
 
 #include "rendering/videomaterial.h"
 
-class VideoNode : public QSGGeometryNode
+class VideoNode : public QSGSimpleTextureNode
 {
 public:
     VideoNode();
 
-    void setRect(const QRectF &rect, const QRectF &sourceRect);
     void updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame);
-
-private:
-    QSGGeometry m_geometry;
-    VideoMaterial m_material;
 };

--- a/src/qml/rendering/videonode.h
+++ b/src/qml/rendering/videonode.h
@@ -24,10 +24,17 @@
 
 #include "rendering/videomaterial.h"
 
+namespace {
+class AbstractVideoFrame;
+}
+
 class VideoNode : public QSGSimpleTextureNode
 {
 public:
     VideoNode();
 
     void updateFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame);
+
+private:
+    std::shared_ptr<Vlc::AbstractVideoFrame> m_frame;
 };

--- a/src/qml/video/videostream.cpp
+++ b/src/qml/video/videostream.cpp
@@ -79,9 +79,6 @@ void VideoStream::deregisterVideoOutput(VideoOutput *output)
 
 void VideoStream::frameUpdated()
 {
-    //    std::shared_ptr<const Vlc::VideoFrame> frame = std::dynamic_pointer_cast<const
-    //    Vlc::VideoFrame>(getVideoFrame());
-
     auto frame = m_videostream->getVideoFrame();
 
     for (auto *output : m_attachedOutputs) {

--- a/src/qml/video/videostream.cpp
+++ b/src/qml/video/videostream.cpp
@@ -23,7 +23,7 @@
 
 include <core/openglvideostream.h>
 
-VideoStream::VideoStream(QObject *parent)
+VideoStream::VideoStream(QQuickItem *parent)
     : QObject(parent)
 {
     m_videostream = std::make_unique<Vlc::OpenGLVideoStream>();

--- a/src/qml/video/videostream.cpp
+++ b/src/qml/video/videostream.cpp
@@ -51,6 +51,11 @@ void VideoStream::initContext()
     m_videostream->initContext();
 }
 
+void VideoStream::windowChanged(QQuickWindow *window)
+{
+    m_videostream->windowChanged(window);
+}
+
 void VideoStream::deinit()
 {
     m_videostream->unsetCallbacks(m_player);

--- a/src/qml/video/videostream.cpp
+++ b/src/qml/video/videostream.cpp
@@ -21,12 +21,24 @@
 #include "core/mediaplayer.h"
 #include "videooutput.h"
 
-include <core/openglvideostream.h>
+#if defined(Q_OS_WIN)
+#include <core/d3d11videostream.h>
+#endif
+#include <core/openglvideostream.h>
 
 VideoStream::VideoStream(QQuickItem *parent)
     : QObject(parent)
 {
-    m_videostream = std::make_unique<Vlc::OpenGLVideoStream>();
+#if defined(Q_OS_WIN)
+    if (QQuickWindow::graphicsApi() == QSGRendererInterface::Direct3D11) {
+        m_videostream = std::make_unique<Vlc::D3D11VideoStream>();
+    } else
+#endif
+    if (QQuickWindow::graphicsApi() == QSGRendererInterface::OpenGLRhi) {
+        m_videostream = std::make_unique<Vlc::OpenGLVideoStream>();
+    }
+    else
+        assert(false);
 
     connect(
         m_videostream.get(), &Vlc::AbstractVideoStream::frameUpdated,

--- a/src/qml/video/videostream.cpp
+++ b/src/qml/video/videostream.cpp
@@ -91,9 +91,12 @@ void VideoStream::deregisterVideoOutput(VideoOutput *output)
 
 void VideoStream::frameUpdated()
 {
-    auto frame = m_videostream->getVideoFrame();
-
     for (auto *output : m_attachedOutputs) {
-        output->presentFrame(frame);
+        output->presentFrame();
     }
+}
+
+std::shared_ptr<Vlc::AbstractVideoFrame> VideoStream::getVideoFrame()
+{
+    return m_videostream->getVideoFrame();
 }

--- a/src/qml/video/videostream.h
+++ b/src/qml/video/videostream.h
@@ -26,6 +26,7 @@ class VideoOutput;
 namespace Vlc {
 class MediaPlayer;
 class AbstractVideoStream;
+class AbstractVideoFrame;
 };
 
 class VideoStream : public QObject
@@ -45,6 +46,8 @@ public:
 
     void registerVideoOutput(VideoOutput *output);
     void deregisterVideoOutput(VideoOutput *output);
+
+    std::shared_ptr<Vlc::AbstractVideoFrame> getVideoFrame();
 
 private:
     void frameUpdated();

--- a/src/qml/video/videostream.h
+++ b/src/qml/video/videostream.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include <core/openglvideostream.h>
-
 #include <QObject>
 #include <set>
 
@@ -27,10 +25,12 @@ class VideoOutput;
 
 namespace Vlc {
 class MediaPlayer;
+class AbstractVideoStream;
 };
 
-class VideoStream : public Vlc::OpenGLVideoStream
+class VideoStream : public QObject
 {
+    Q_OBJECT
 public:
     explicit VideoStream(QObject *parent = nullptr);
 
@@ -39,12 +39,15 @@ public:
     void init(Vlc::MediaPlayer *player);
     void deinit();
 
+    void initContext();
+
     void registerVideoOutput(VideoOutput *output);
     void deregisterVideoOutput(VideoOutput *output);
 
 private:
-    Q_INVOKABLE virtual void frameUpdated() override;
+    void frameUpdated();
 
+    std::unique_ptr<Vlc::AbstractVideoStream> m_videostream;
     std::set<VideoOutput *> m_attachedOutputs;
 
     Vlc::MediaPlayer *m_player;

--- a/src/qml/video/videostream.h
+++ b/src/qml/video/videostream.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <QObject>
+#include <QtQuick/QQuickItem>
 #include <set>
 
 class VideoOutput;
@@ -32,7 +32,7 @@ class VideoStream : public QObject
 {
     Q_OBJECT
 public:
-    explicit VideoStream(QObject *parent = nullptr);
+    explicit VideoStream(QQuickItem *parent = nullptr);
 
     ~VideoStream();
 

--- a/src/qml/video/videostream.h
+++ b/src/qml/video/videostream.h
@@ -41,6 +41,8 @@ public:
 
     void initContext();
 
+    void windowChanged(QQuickWindow *window);
+
     void registerVideoOutput(VideoOutput *output);
     void deregisterVideoOutput(VideoOutput *output);
 
@@ -50,5 +52,5 @@ private:
     std::unique_ptr<Vlc::AbstractVideoStream> m_videostream;
     std::set<VideoOutput *> m_attachedOutputs;
 
-    Vlc::MediaPlayer *m_player;
+    Vlc::MediaPlayer *m_player = nullptr;
 };

--- a/src/qml/videooutput.cpp
+++ b/src/qml/videooutput.cpp
@@ -108,7 +108,7 @@ void VideoOutput::setCropRatio(int cropRatio)
     emit cropRatioChanged();
 }
 
-void VideoOutput::presentFrame(const std::shared_ptr<Vlc::VideoFrame> &frame)
+void VideoOutput::presentFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
 {
     m_frame = frame;
 

--- a/src/qml/videooutput.cpp
+++ b/src/qml/videooutput.cpp
@@ -108,12 +108,9 @@ void VideoOutput::setCropRatio(int cropRatio)
     emit cropRatioChanged();
 }
 
-void VideoOutput::presentFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame)
+void VideoOutput::presentFrame()
 {
-    m_frame = frame;
-
     m_frameUpdated = true;
-
     update();
 }
 
@@ -123,27 +120,33 @@ QSGNode *VideoOutput::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *dat
 
     VideoNode *node = static_cast<VideoNode *>(oldNode);
 
-    if (!m_frame) {
-        delete node;
-
+    if (!m_source) {
+        if (node)
+            delete node;
         return nullptr;
-    }
-
-    if (!node) {
-        node = new VideoNode();
     }
 
     if (m_frameUpdated) {
         m_frameUpdated = false;
+        m_frame = m_source->getVideoFrame();
+
+        if (!m_frame) {
+            if (node)
+                delete node;
+            return nullptr;
+        }
+
+        if (!node) {
+            node = new VideoNode();
+        }
 
         node->updateFrame(m_frame);
+        auto rects = calculateFillMode(m_frame->width(), m_frame->height());
+
+        // FIXME
+        node->setRect(rects.out);
+        // node->setSourceRect(rects.source);
     }
-
-    auto rects = calculateFillMode(m_frame->width(), m_frame->height());
-
-    //FIXME
-    node->setRect(rects.out);
-    //node->setSourceRect(rects.source);
 
     return node;
 }

--- a/src/qml/videooutput.cpp
+++ b/src/qml/videooutput.cpp
@@ -141,7 +141,9 @@ QSGNode *VideoOutput::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *dat
 
     auto rects = calculateFillMode(m_frame->width(), m_frame->height());
 
-    node->setRect(rects.out, rects.source);
+    //FIXME
+    node->setRect(rects.out);
+    //node->setSourceRect(rects.source);
 
     return node;
 }

--- a/src/qml/videooutput.h
+++ b/src/qml/videooutput.h
@@ -67,7 +67,7 @@ public:
 
     void setCropRatio(int cropRatio);
 
-    void presentFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame);
+    void presentFrame();
 
 signals:
     void contextReady(QOpenGLContext *ctx);

--- a/src/qml/videooutput.h
+++ b/src/qml/videooutput.h
@@ -67,7 +67,7 @@ public:
 
     void setCropRatio(int cropRatio);
 
-    void presentFrame(const std::shared_ptr<Vlc::VideoFrame> &frame);
+    void presentFrame(const std::shared_ptr<Vlc::AbstractVideoFrame> &frame);
 
 signals:
     void contextReady(QOpenGLContext *ctx);


### PR DESCRIPTION
Hi, here is a first implementation of D3D support.

You will notice that I had to do quite some changes in your architecture to be able to support 2 backends.

Notably, I remove the use of a custom shader to directly use QSGSimpleTexture along with QSG native texture wrapper provided in Qt6. I didn't really see the need of a custom shader but maybe I missed something.

there are still some rough edges to polish but this first version should work for most cases.

in order to test my patch I use the following modifications in QuickVLC-exemples

```diff
diff --git a/main.cpp b/main.cpp
index e992e23..4944adb 100644
--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,29 @@
 #include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlEngine>
+#include <QQuickWindow>

 int main(int argc, char *argv[])
 {
     // this important so we can call makeCurrent from our rendering thread
     QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);

+    bool useGL = false;
+    if (argc > 1) {
+        for (int i = 1; i < argc; i++) {
+            if (QString(argv[i]) == "--gl") {
+                useGL = true;
+                break;
+            }
+        }
+    }
+
+    if (useGL) {
+        QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
+    } else {
+        QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D11Rhi);
+    }
+
     QApplication app(argc, argv);

     QQmlApplicationEngine engine;
diff --git a/main.qml b/main.qml
index a696943..84cc487 100644
--- a/main.qml
+++ b/main.qml
@@ -58,7 +58,9 @@ ApplicationWindow {

         Rectangle {
             anchors.fill: parent
-            color: "#000000"
+            color: "red"
+
+            ColorAnimation on color { to: "yellow"; duration: 1000; loops: Animation.Infinite }
         }

         MediaPlayer
```

feedbacks are welcomed

fix #6 