### PR TITLE
Pool lifecycle

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,7 +30,7 @@ set(QUICKVLC_CORE_HEADERS
     abstractvideostream.h
     vlc.h
     abstractvideoframe.h
-    videoframe.h
+    videoframepool.h
 )
 
 set(QUICKVLC_CORE_SOURCES
@@ -43,14 +43,13 @@ set(QUICKVLC_CORE_SOURCES
     abstractvideostream.cpp
     vlc.cpp
     abstractvideoframe.cpp
-    videoframe.cpp
+    videoframepool.cpp
 )
 
 IF(MSVC OR MINGW)
     list(APPEND QUICKVLC_CORE_SOURCES
         compat/asprintf.c
         compat/vasprintf.c
-        d3d11videostream.h
     )
     list(APPEND QUICKVLC_CORE_SOURCES
         d3d11videostream.cpp
@@ -61,9 +60,11 @@ IF(MSVC OR MINGW)
 ENDIF()
 list(APPEND QUICKVLC_CORE_HEADERS
     openglvideostream.h
+    openglvideoframe.h
 )
 list(APPEND QUICKVLC_CORE_SOURCES
     openglvideostream.cpp
+    openglvideoframe.cpp
 )
 
 

--- a/src/core/openglvideoframe.cpp
+++ b/src/core/openglvideoframe.cpp
@@ -17,18 +17,17 @@
  * along with QuickVLC. If not, see <https://www.gnu.org/licenses/>.
  ******************************************************************************/
 
-#include "videoframe.h"
+#include "openglvideoframe.h"
 #include <QtQuick/qsgtexture_platform.h>
 
 namespace Vlc {
 
-OpenGLVideoFrame::OpenGLVideoFrame(QOpenGLFramebufferObject *fbo, QQuickWindow* window) 
+OpenGLVideoFrame::OpenGLVideoFrame(int width, int height, QQuickWindow *window) 
     : AbstractVideoFrame()
+    , m_fbo(width, height)
     , m_window(window)
 {
-    m_textureId = fbo->texture();
-
-    setSize(fbo->size());
+    setSize(m_fbo.size());
 }
 
 OpenGLVideoFrame::~OpenGLVideoFrame()
@@ -37,7 +36,7 @@ OpenGLVideoFrame::~OpenGLVideoFrame()
 
 GLuint OpenGLVideoFrame::texture() const
 {
-    return m_textureId;
+    return m_fbo.texture();
 }
 
 bool OpenGLVideoFrame::isFlipped() const
@@ -48,7 +47,8 @@ bool OpenGLVideoFrame::isFlipped() const
 
 QSGTexture *OpenGLVideoFrame::getQSGTexture()
 {
-    return QNativeInterface::QSGOpenGLTexture::fromNative(m_textureId, m_window, size());
+    return QNativeInterface::QSGOpenGLTexture::fromNative(
+        m_fbo.texture(), m_window, size());
 }
 
 }  // namespace Vlc

--- a/src/core/openglvideoframe.h
+++ b/src/core/openglvideoframe.h
@@ -20,6 +20,9 @@
 #pragma once
 
 #include <QOpenGLFramebufferObject>
+#include <QQueue>
+#include <QMutex>
+#include <QWaitCondition>
 
 #include "abstractvideoframe.h"
 #include "core_shared_export.h"
@@ -29,9 +32,14 @@ namespace Vlc {
 class QUICKVLC_CORE_EXPORT OpenGLVideoFrame : public AbstractVideoFrame
 {
 public:
-    explicit OpenGLVideoFrame(QOpenGLFramebufferObject *fbo, QQuickWindow *window);
+    explicit OpenGLVideoFrame(int width, int height, QQuickWindow *window);
 
     ~OpenGLVideoFrame();
+
+    QOpenGLFramebufferObject &fbo()
+    {
+        return m_fbo;
+    }
 
     GLuint texture() const;
 
@@ -40,8 +48,8 @@ public:
     QSGTexture *getQSGTexture() override;
 
 private:
-    GLuint m_textureId;
-    QQuickWindow *m_window;
+    QOpenGLFramebufferObject m_fbo;
+    QQuickWindow *m_window = nullptr;
 };
 
 }  // namespace Vlc

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -69,7 +69,8 @@ std::shared_ptr<AbstractVideoFrame> OpenGLVideoStream::getVideoFrame()
     QMutexLocker locker(&m_text_lock);
 
     if (m_updated) {
-        std::swap(m_idx_swap, m_idx_display);
+        std::swap(m_idx_swap1, m_idx_swap2);
+        std::swap(m_idx_swap2, m_idx_display);
 
         if (m_buffers[m_idx_display]) {
             m_videoFrame = std::make_shared<OpenGLVideoFrame>(m_buffers[m_idx_display].get(), m_window);
@@ -147,7 +148,7 @@ void OpenGLVideoStream::swap()
 
     m_updated = true;
 
-    std::swap(m_idx_swap, m_idx_render);
+    std::swap(m_idx_swap1, m_idx_render);
 
     emit frameUpdated();
 

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -69,35 +69,28 @@ std::shared_ptr<AbstractVideoFrame> OpenGLVideoStream::getVideoFrame()
     QMutexLocker locker(&m_text_lock);
 
     if (m_updated) {
-        std::swap(m_idx_swap1, m_idx_swap2);
-        std::swap(m_idx_swap2, m_idx_display);
-
-        if (m_buffers[m_idx_display]) {
-            m_videoFrame = std::make_shared<OpenGLVideoFrame>(m_buffers[m_idx_display].get(), m_window);
-        } else {
-            m_videoFrame = {};
-        }
-
         m_updated = false;
     }
 
-    return m_videoFrame;
+    return m_readyFrame;
 }
 
 bool OpenGLVideoStream::updateOutput(const libvlc_video_render_cfg_t *cfg, libvlc_video_output_cfg_t *render_cfg)
 {
     {
         QMutexLocker locker(&m_text_lock);
-
-        for (auto &buffer : m_buffers) {
-            buffer = std::make_unique<QOpenGLFramebufferObject>(cfg->width, cfg->height);
-        }
+        m_pool = std::make_shared<VideoFramePool>();
+        for (int i = 0; i < 5; i++)
+            m_pool->enqueue(new OpenGLVideoFrame(cfg->width, cfg->height, m_window));
+        AbstractVideoFrame* frame = m_pool->pop(0);
+        assert(frame);
+        m_renderingFrame = std::make_shared<PooledVideoFrame>(frame, m_pool);
     }
 
     m_width = cfg->width;
     m_height = cfg->height;
 
-    m_buffers[m_idx_render]->bind();
+    m_renderingFrame->as<OpenGLVideoFrame>()->fbo().bind();
 
     render_cfg->opengl_format = GL_RGBA;
     render_cfg->full_range = true;
@@ -137,9 +130,9 @@ void OpenGLVideoStream::cleanup()
         return;
     }
 
-    for (auto &buffer : m_buffers) {
-        buffer.reset(nullptr);
-    }
+    m_renderingFrame.reset();
+    m_readyFrame.reset();
+    m_pool.reset();
 }
 
 void OpenGLVideoStream::swap()
@@ -148,11 +141,14 @@ void OpenGLVideoStream::swap()
 
     m_updated = true;
 
-    std::swap(m_idx_swap1, m_idx_render);
-
+    m_renderingFrame->as<OpenGLVideoFrame>()->fbo().release();
+    m_readyFrame = m_renderingFrame;
     emit frameUpdated();
 
-    m_buffers[m_idx_render]->bind();
+    AbstractVideoFrame* frame = m_pool->pop(0);
+    assert(frame);
+    m_renderingFrame = std::make_shared<PooledVideoFrame>(frame, m_pool);
+    m_renderingFrame->as<OpenGLVideoFrame>()->fbo().bind();
 }
 
 bool OpenGLVideoStream::selectPlane(size_t plane, void *output)

--- a/src/core/openglvideostream.cpp
+++ b/src/core/openglvideostream.cpp
@@ -38,25 +38,22 @@ OpenGLVideoStream::~OpenGLVideoStream()
 void OpenGLVideoStream::windowChanged(QQuickWindow *window)
 {
     m_window = window;
+
+    window->format();
+    m_surface->setFormat(window->format());
+    m_surface->create();
 }
 
 void OpenGLVideoStream::initContext()
 {
-    //    Q_ASSERT(QSGRendererInterface::isApiRhiBased(QSGRendererInterface::OpenGL));
-
     if (m_context->isValid()) {
         return;
     }
 
     auto *context = QOpenGLContext::currentContext();
-
-    m_surface->setFormat(context->format());
-    m_surface->create();
-
     m_context->setFormat(context->format());
     m_context->setShareContext(context);
     m_context->create();
-
     initializeOpenGLFunctions();
 
     m_videoReady.release();

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -62,10 +62,11 @@ private:
 
     QMutex m_text_lock;
 
-    std::unique_ptr<QOpenGLFramebufferObject> m_buffers[3];
+    std::unique_ptr<QOpenGLFramebufferObject> m_buffers[4];
     size_t m_idx_render = 0;
-    size_t m_idx_swap = 1;
-    size_t m_idx_display = 2;
+    size_t m_idx_swap1 = 1;
+    size_t m_idx_swap2 = 2;
+    size_t m_idx_display = 3;
 
     bool m_updated = false;
 

--- a/src/core/openglvideostream.h
+++ b/src/core/openglvideostream.h
@@ -27,7 +27,8 @@
 
 #include "abstractvideostream.h"
 #include "core_shared_export.h"
-#include "videoframe.h"
+#include "openglvideoframe.h"
+#include "videoframepool.h"
 
 namespace Vlc {
 
@@ -62,15 +63,12 @@ private:
 
     QMutex m_text_lock;
 
-    std::unique_ptr<QOpenGLFramebufferObject> m_buffers[4];
-    size_t m_idx_render = 0;
-    size_t m_idx_swap1 = 1;
-    size_t m_idx_swap2 = 2;
-    size_t m_idx_display = 3;
+    std::shared_ptr<PooledVideoFrame> m_renderingFrame;
+    std::shared_ptr<PooledVideoFrame> m_readyFrame;
+
+    std::shared_ptr<VideoFramePool> m_pool;
 
     bool m_updated = false;
-
-    std::shared_ptr<OpenGLVideoFrame> m_videoFrame;
 };
 
 }  // namespace Vlc

--- a/src/qml/rendering/videomaterial.h
+++ b/src/qml/rendering/videomaterial.h
@@ -20,7 +20,7 @@
 
 #include <QSGMaterial>
 
-#include "core/videoframe.h"
+#include "core/abstractvideoframe.h"
 #include "rendering/videotexture.h"
 
 class VideoMaterial : public QSGMaterial

--- a/src/qml/rendering/videonode.h
+++ b/src/qml/rendering/videonode.h
@@ -18,9 +18,10 @@
 
 #pragma once
 
-#include <core/videoframe.h>
+#include <core/abstractvideoframe.h>
 
 #include <QSGSimpleTextureNode>
+#include <QMutex>
 
 #include "rendering/videomaterial.h"
 
@@ -37,4 +38,5 @@ public:
 
 private:
     std::shared_ptr<Vlc::AbstractVideoFrame> m_frame;
+    bool m_updated = false;
 };

--- a/src/qml/videooutput.h
+++ b/src/qml/videooutput.h
@@ -22,9 +22,9 @@
 #include <QPointer>
 #include <QQuickItem>
 #include <QQuickWindow>
+#include <QMutex>
 
 #include "core/abstractvideoframe.h"
-#include "core/videoframe.h"
 #include "core/vlc.h"
 #include "mediasource.h"
 #include "qml_shared_export.h"
@@ -94,6 +94,6 @@ private:
     Vlc::Enum::Ratio m_aspectRatio;
     Vlc::Enum::Ratio m_cropRatio;
 
-    std::shared_ptr<Vlc::AbstractVideoFrame> m_frame;
     bool m_frameUpdated;
+    QMutex m_frameMutex;
 };


### PR DESCRIPTION
Change the fixed triple buffering swapchain to a pool based implementation

this should provide a clearer view about who owns which buffer at what time,
a buffer is either in the pool, in rendering or attached to a QSGNode

This may also avoid some racy scenarios where the framebuffers are released by
VLC while still in used by Qt, the pool exists as long as some buffers are
referencing it


Note that this branch contains commits from #12 